### PR TITLE
- make sure that order in sub arrays is preserved

### DIFF
--- a/src/excel_to_json/converter.clj
+++ b/src/excel_to_json/converter.clj
@@ -8,6 +8,10 @@
 
 (def data-formatter (DataFormatter.))
 
+(defn conj*
+  [s x]
+  (conj (vec s) x))
+
 (defn split-keys [k]
   (map keyword (clojure.string/split (name k) #"\.")))
 
@@ -104,7 +108,7 @@
                           (if (empty? sub)
                             acc
                             (if (blank? nested-key)
-                              (update-in acc [secondary-key] conj sub)
+                              (update-in acc [secondary-key] conj* sub)
                               (assoc-in (ensure-ordered acc secondary-key)
                                         [secondary-key safe-nested-key] sub)))))
                       acc0 secondary-config)))

--- a/test/excel_to_json/converter_test.clj
+++ b/test/excel_to_json/converter_test.clj
@@ -26,9 +26,9 @@
                        :property_b 7.00M
                        :property_c {:baz "90%" :qux "3300%"}}}
                      :properties
-                     [{:prop_a "baz_3" :prop_b 300}
+                     [{:prop_a "baz_1" :prop_b 100}
                       {:prop_a "baz_2" :prop_b 200}
-                      {:prop_a "baz_1" :prop_b 100}]}
+                      {:prop_a "baz_3" :prop_b 300}]}
                     {:id "bar"
                      :property_1 900
                      :property_2 false
@@ -42,8 +42,8 @@
                        :property_b 5.00M
                        :property_c {:baz "85%" :qux "5500%"}}}
                      :properties
-                     [{:prop_a "baz_5" :prop_b 500}
-                      {:prop_a "baz_4" :prop_b 400}]}]]]]
+                     [{:prop_a "baz_4" :prop_b 400}
+                      {:prop_a "baz_5" :prop_b 500}]}]]]]
     (is (= expected configs))))
 
 (deftest convert-array


### PR DESCRIPTION
Howdi - there's one tiny problem with arrays generated from sub-sheets that the sorting order is not deterministic ... Making sure that the list is a vector seems to do the trick